### PR TITLE
Utilize dnn_DetectionModel set input size to 640

### DIFF
--- a/Tracker.py
+++ b/Tracker.py
@@ -13,6 +13,8 @@ import os
 
 #  setttng up opencv net
 net = cv2.dnn.readNetFromONNX("yolov5n.onnx")
+net = cv2.dnn_DetectionModel(net)
+net.setInputParams(size=(640,640), scale=1/255, swapRB=True)
 
 # getting class names from classes.txt file
 #yolo


### PR DESCRIPTION
In order to use `detect` function, you need to initialize `cv2.dnn_DetectionModel()`.
This Pull request contains 2 changes.
 1. Use `cv2.dnn_DetectionModel()`
 2. Set input size to 640,640
